### PR TITLE
refactor: remove satori uuid package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday v1.6.0
-	github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5
 	github.com/sethvargo/go-envconfig v0.3.5
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -729,8 +729,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5 h1:Jw7W4WMfQDxsXvfeFSaS2cHlY7bAF4MGrgnbd0+Uo78=
-github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/pkg/kube/naming/names.go
+++ b/pkg/kube/naming/names.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"unicode"
 
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 )
 
 // ToValidImageName converts the given string into a valid docker image name
@@ -46,8 +46,7 @@ func ToValidNameWithDotsTruncated(name string, maxLength int) string {
 // truncating the result if it is more than 30 characters.
 func ToValidGCPServiceAccount(name string) string {
 	if len(name) < 6 {
-		uuid4, _ := uuid.NewV4()
-		name = fmt.Sprintf("%s-jx-%s", name, uuid4.String()[:1])
+		name = fmt.Sprintf("%s-jx-%s", name, uuid.New().String()[:1])
 	}
 	return toValidName(name, false, 30)
 }


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

 This is a dead repo, and also does not generate uuids and we already use google uuid everywhere else.
Source: 
* https://github.com/satori/go.uuid/issues/103
* https://github.com/satori/go.uuid/issues/73