### PR TITLE
finding url from istio virtual service

### DIFF
--- a/pkg/kube/services/services_test.go
+++ b/pkg/kube/services/services_test.go
@@ -431,7 +431,7 @@ func TestGetUrlFromVirtualService(t *testing.T) {
 	dynamicClient := fakedyn.NewSimpleDynamicClient(scheme)
 	url, err := services.FindUrlFromVsIstio(dynamicClient, namespace, name)
 	assert.Equal(t, url, "")
-	assert.EqualError(t, err, "virtualservices.networking.istio.io \""+name+"\" not found")
+	assert.NoError(t, err)
 	// case with a virtual service in the given namespace
 	virtualService := &unstructured.Unstructured{}
 	virtualService.SetUnstructuredContent(map[string]interface{}{

--- a/pkg/kube/services/services_test.go
+++ b/pkg/kube/services/services_test.go
@@ -12,6 +12,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	nv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakedyn "k8s.io/client-go/dynamic/fake"
 )
 
 func TestExtractServiceSchemePortDefault(t *testing.T) {
@@ -418,4 +421,34 @@ func TestFindURLFromIngress(t *testing.T) {
 		assert.Equal(t, tc.ExpectedURL, actual, "IngressURL for %s", tc.Name)
 		t.Logf("test %s generated URL from Ingress %s", tc.Name, actual)
 	}
+}
+
+func TestGetUrlFromVirtualService(t *testing.T) {
+	var namespace = "default"
+	var name = "jenkins"
+	// case when there is no virtual service
+	scheme := runtime.NewScheme()
+	dynamicClient := fakedyn.NewSimpleDynamicClient(scheme)
+	url, err := services.FindUrlFromVsIstio(dynamicClient, namespace, name)
+	assert.Equal(t, url, "")
+	assert.EqualError(t, err, "virtualservices.networking.istio.io \""+name+"\" not found")
+	// case with a virtual service in the given namespace
+	virtualService := &unstructured.Unstructured{}
+	virtualService.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "networking.istio.io/v1alpha3",
+		"kind":       "VirtualService",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]interface{}{
+			"hosts": []interface{}{"testing.jenkins-x.in"},
+		},
+	})
+	dynamicClient = fakedyn.NewSimpleDynamicClient(scheme, virtualService)
+	url, err = services.FindUrlFromVsIstio(dynamicClient, namespace, name)
+	if assert.NoError(t, err) {
+		assert.Equal(t, url, "testing.jenkins-x.in")
+	}
+	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION
We are not able to find preview url as we are using istio.
Also in jenkins-x ligthouse it asks for ingress so if this function also search the url through istio virtual service.
Not using istio-client-go as it will add more dependencies in the code.
Using dynamic client to find virtual service in the given namespace and service.
as the hosts is an array so returning the first element in the list.