### PR TITLE
fix: Deletion of old plugin versions

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,4 @@
 approvers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ankitm123
+- maintainers
 reviewers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ankitm123
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,3 @@
-aliases:
-- rawlingsj
-best-approvers:
-- rawlingsj
-best-reviewers:
-- rawlingsj
+foreignAliases:
+- name: jx-community
+  org: jenkins-x

--- a/pkg/cobras/templates/templates.go
+++ b/pkg/cobras/templates/templates.go
@@ -83,7 +83,7 @@ func MainUsageTemplate() string {
 
 // OptionsHelpTemplate if the template for 'help' used by the 'options' command.
 func OptionsHelpTemplate() string {
-	return "Dispaly a list of global command-line options\n"
+	return "Display a list of global command-line options\n"
 }
 
 // OptionsUsageTemplate if the template for 'usage' used by the 'options' command.

--- a/pkg/extensions/plugins.go
+++ b/pkg/extensions/plugins.go
@@ -176,11 +176,7 @@ func EnsurePluginInstalledForAliasFile(plugin jxCore.Plugin, pluginBinDir string
 			return path, err
 		}
 		deleted := make([]string, 0)
-		// lets only delete plugins for this major version so we can keep, say, helm 2 and 3 around
-		prefix := plugin.Name + "-"
-		if len(version) > 0 {
-			prefix += version[0:1]
-		}
+		prefix := pluginName + "-"
 		for _, f := range fileObs {
 			if strings.HasPrefix(f.Name(), prefix) {
 				err = os.Remove(filepath.Join(pluginBinDir, f.Name()))


### PR DESCRIPTION
The code to delete old versions of a plugin when installing a new one is broken. (My ~/.jx3/plugins/bin is over 7GB.)

Also removing code for saving old versions. I don't know any circumstance when this would be used.

Fixing a typo while at it