### PR TITLE
fix: Show plugins in help for jx

### DIFF
--- a/pkg/cobras/templates/command_groups.go
+++ b/pkg/cobras/templates/command_groups.go
@@ -53,7 +53,7 @@ func AddAdditionalCommands(g CommandGroups, message string, cmds []*cobra.Comman
 	group := CommandGroup{Message: message}
 	for _, c := range cmds {
 		// Don't show commands that have no short description
-		if !g.Has(c) && len(c.Short) != 0 {
+		if !g.Has(c) && len(c.Short) != 0 && c.Runnable() {
 			group.Commands = append(group.Commands, c)
 		}
 	}

--- a/pkg/cobras/templates/helpers.go
+++ b/pkg/cobras/templates/helpers.go
@@ -35,9 +35,9 @@ func (o *Options) GetPluginCommandGroups(verifier extensions.PathVerifier, local
 	}
 	groups := make(map[string]PluginCommandGroup, 0)
 
-	o.addPlugins(localPlugins, otherCommands, groups)
+	o.addPlugins(localPlugins, &otherCommands, groups)
 
-	err := o.addManagedPlugins(otherCommands, groups)
+	err := o.addManagedPlugins(&otherCommands, groups)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to add managed plugins")
 	}
@@ -97,7 +97,7 @@ func (o *Options) GetPluginCommandGroups(verifier extensions.PathVerifier, local
 	return pcgs, nil
 }
 
-func (o *Options) addManagedPlugins(otherCommands PluginCommandGroup, groups map[string]PluginCommandGroup) error {
+func (o *Options) addManagedPlugins(otherCommands *PluginCommandGroup, groups map[string]PluginCommandGroup) error {
 	// Managed plugins
 	var err error
 	if o.ManagedPluginsEnabled {
@@ -117,7 +117,7 @@ func (o *Options) addManagedPlugins(otherCommands PluginCommandGroup, groups map
 	return nil
 }
 
-func (o *Options) addPlugins(pluginSlice []jxCore.Plugin, otherCommands PluginCommandGroup, groups map[string]PluginCommandGroup) {
+func (o *Options) addPlugins(pluginSlice []jxCore.Plugin, otherCommands *PluginCommandGroup, groups map[string]PluginCommandGroup) {
 	for _, plugin := range pluginSlice {
 		pluginCommand := &PluginCommand{
 			PluginSpec: plugin.Spec,

--- a/pkg/cobras/templates/templater.go
+++ b/pkg/cobras/templates/templater.go
@@ -170,7 +170,6 @@ func (t *templater) cmdGroupsString(c *cobra.Command) string {
 		for _, cmd := range cmdGroup.Commands {
 			if cmd.Runnable() {
 				path := t.groupPath(cmd)
-				//cmds = append(cmds, "  "+rpad(path, maxLen - len(path))+" "+cmd.Short)
 				cmds = append(cmds, "  "+table.PadRight(termcolor.ColorInfo(path), " ", maxLen)+" "+cmd.Short)
 			}
 		}
@@ -180,7 +179,6 @@ func (t *templater) cmdGroupsString(c *cobra.Command) string {
 		for _, cmdGroup := range pluginCommandGroups {
 			cmds := []string{cmdGroup.Message}
 			for _, cmd := range cmdGroup.Commands {
-				//cmds = append(cmds, "  "+rpad(path, maxLen - len(path))+" "+cmd.Short)
 				cmds = append(cmds, "  "+table.PadRight(termcolor.ColorInfo(cmd.SubCommand), " ", maxLen)+" "+fmt.Sprintf("%s (from plugin)", cmd.Description))
 			}
 			groups = append(groups, strings.Join(cmds, "\n"))

--- a/pkg/cobras/templates/templater.go
+++ b/pkg/cobras/templates/templater.go
@@ -94,7 +94,6 @@ func (templater *templater) templateFuncs(exposedFlags ...string) template.FuncM
 		"cmdGroupsString":     templater.cmdGroupsString,
 		"rootCmd":             templater.rootCmdName,
 		"isRootCmd":           templater.isRootCmd,
-		"optionsCmdFor":       templater.optionsCmdFor,
 		"usageLine":           templater.usageLine,
 		"exposed": func(c *cobra.Command) *flag.FlagSet {
 			exposed := flag.NewFlagSet("exposed", flag.ContinueOnError)
@@ -156,11 +155,13 @@ func (t *templater) cmdGroupsString(c *cobra.Command) string {
 		}
 	}
 	pluginCommandGroups, _ := t.GetPluginCommandGroups()
-	for _, cmdGroup := range pluginCommandGroups {
-		for _, cmd := range cmdGroup.Commands {
-			l := len(cmd.SubCommand)
-			if l > maxLen {
-				maxLen = l
+	if c == t.RootCmd {
+		for _, cmdGroup := range pluginCommandGroups {
+			for _, cmd := range cmdGroup.Commands {
+				l := len(cmd.SubCommand)
+				if l > maxLen {
+					maxLen = l
+				}
 			}
 		}
 	}
@@ -175,13 +176,15 @@ func (t *templater) cmdGroupsString(c *cobra.Command) string {
 		}
 		groups = append(groups, strings.Join(cmds, "\n"))
 	}
-	for _, cmdGroup := range pluginCommandGroups {
-		cmds := []string{cmdGroup.Message}
-		for _, cmd := range cmdGroup.Commands {
-			//cmds = append(cmds, "  "+rpad(path, maxLen - len(path))+" "+cmd.Short)
-			cmds = append(cmds, "  "+table.PadRight(termcolor.ColorInfo(cmd.SubCommand), " ", maxLen)+" "+fmt.Sprintf("%s (from plugin)", cmd.Description))
+	if c == t.RootCmd {
+		for _, cmdGroup := range pluginCommandGroups {
+			cmds := []string{cmdGroup.Message}
+			for _, cmd := range cmdGroup.Commands {
+				//cmds = append(cmds, "  "+rpad(path, maxLen - len(path))+" "+cmd.Short)
+				cmds = append(cmds, "  "+table.PadRight(termcolor.ColorInfo(cmd.SubCommand), " ", maxLen)+" "+fmt.Sprintf("%s (from plugin)", cmd.Description))
+			}
+			groups = append(groups, strings.Join(cmds, "\n"))
 		}
-		groups = append(groups, strings.Join(cmds, "\n"))
 	}
 	return fmt.Sprintf("%s\n", strings.Join(groups, "\n\n"))
 }
@@ -211,20 +214,6 @@ func (t *templater) rootCmd(c *cobra.Command) *cobra.Command {
 		panic("nil root cmd")
 	}
 	return t.RootCmd
-}
-
-func (t *templater) optionsCmdFor(c *cobra.Command) string {
-	if !c.Runnable() {
-		return ""
-	}
-	rootCmdStructure := t.parents(c)
-	for i := len(rootCmdStructure) - 1; i >= 0; i-- {
-		cmd := rootCmdStructure[i]
-		if _, _, err := cmd.Find([]string{"options"}); err == nil {
-			return cmd.CommandPath() + " options"
-		}
-	}
-	return ""
 }
 
 func (t *templater) usageLine(c *cobra.Command) string {

--- a/pkg/cobras/templates/templates.go
+++ b/pkg/cobras/templates/templates.go
@@ -24,7 +24,6 @@ const (
 		`{{$rootCmd := rootCmd .}}` +
 		`{{$visibleFlags := visibleFlags (flagsNotIntersected .LocalFlags .PersistentFlags)}}` +
 		`{{$explicitlyExposedFlags := exposed .}}` +
-		`{{$optionsCmdFor := optionsCmdFor .}}` +
 		`{{$usageLine := usageLine .}}`
 
 	// SectionAliases is the help template section that displays command aliases.
@@ -54,10 +53,6 @@ const (
 	// SectionTipsHelp is the help template section that displays the '--help' hint.
 	SectionTipsHelp = `{{if .HasSubCommands}}Use "{{$rootCmd}} <command> --help" for more information about a given command.
 {{end}}`
-
-	// SectionTipsGlobalOptions is the help template section that displays the 'options' hint for displaying global flags.
-	SectionTipsGlobalOptions = `{{if $optionsCmdFor}}Use "{{$optionsCmdFor}}" for a list of global command-line options (applies to all commands).
-{{end}}`
 )
 
 // MainHelpTemplate if the template for 'help' used by most commands.
@@ -76,7 +71,6 @@ func MainUsageTemplate() string {
 		SectionFlags,
 		SectionUsage,
 		SectionTipsHelp,
-		SectionTipsGlobalOptions,
 	}
 	return strings.TrimRightFunc(strings.Join(sections, ""), unicode.IsSpace)
 }


### PR DESCRIPTION
Also removing options command from help, since we don't have it.