### PR TITLE
fix: updated order of parameters for sparse-checkout 

### DIFF
--- a/pkg/gitclient/helpers.go
+++ b/pkg/gitclient/helpers.go
@@ -382,7 +382,7 @@ func SparseCloneToDir(g Interface, gitURL, dir string, shallow bool, sparseCheck
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to clone repository %s to directory: %s", gitURL, dir)
 	}
-	sparseCheckoutArgs := append([]string{"sparse-checkout", "--no-cone", "set"}, sparseCheckoutPatterns...)
+	sparseCheckoutArgs := append([]string{"sparse-checkout", "set", "--no-cone"}, sparseCheckoutPatterns...)
 	_, err = g.Command(dir, sparseCheckoutArgs...)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to set sparse checkout patterns to %v", sparseCheckoutPatterns)


### PR DESCRIPTION
Fixes an error when using sparse checkout that happens due to the order of parameters
 
git sparse-checkout --no-cone set -> git sparse-checkout set --no-cone 

Now it should follow the example in the [docs](https://git-scm.com/docs/git-sparse-checkout#_internalsfull_pattern_set)
