### PR TITLE
fix: upgradebot config

### DIFF
--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -3,23 +3,10 @@ kind: UpdateConfig
 spec:
   rules:
     - changes:
-        - regex:
-            pattern: |
-              github.com/jenkins-x/jx-helpers v(.*)
-            files:
-              - "go.mod"
         - go:
             owner:
               - jenkins-x-plugins
-            repositories:
-              include:
-                - jx-project
-                - jx-pipeline
-                - jx-admin
-                - jx-preview
-                - jx-updatebot
             package: github.com/jenkins-x/jx-helpers
             upgradePackages:
               include:
-                - "github.com/jenkins-x/*"
-                - "github.com/jenkins-x-plugins/*"
+                - "github.com/jenkins-x/jx-helpers"

--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -6,6 +6,19 @@ spec:
         - go:
             owner:
               - jenkins-x-plugins
+            repositories:
+              exclude:
+                - octant-jx
+                - jx-secret-postrenderer
+                - jx-tap
+                - jx-test-collector
+                - kh-tls-check
+                - jx-tekton-to-actions
+                - jx-kube-test
+                - mink
+                - kuberhealthy-terraform-drift-check
+                - jx-kh-check
+                - jx-plugin-doc
             package: github.com/jenkins-x/jx-helpers
             upgradePackages:
               include:


### PR DESCRIPTION
Upgrading all dependencies almost always fails, so upgrading only jx-helpers.

Removing regex change since it lacks urls and thus doesn't do anything.

Removing include repositories so all plugins get the upgrade except a select few