### PR TITLE
feat: support replacement of chart in version stream

### DIFF
--- a/pkg/versionstream/version_data.go
+++ b/pkg/versionstream/version_data.go
@@ -2,7 +2,12 @@ package versionstream
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
@@ -11,12 +16,6 @@ import (
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
-
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 )
 
 // Callback a callback function for processing version information. Return true to continue processing
@@ -60,6 +59,11 @@ var (
 
 // StableVersion stores the stable version information
 type StableVersion struct {
+	// Indicates that this chart is deprecated and should be replaced with ReplacementChart
+	ReplacementChart string `json:"replacementChart,omitempty"`
+	// ReplacementChartPrefix can hold a replacement chart prefix in case ReplacementChart is set
+	ReplacementChartPrefix string `json:"replacementChartPrefix,omitempty"`
+
 	// Version the default version to use
 	Version string `json:"version,omitempty"`
 	// VersionUpperLimit represents the upper limit which indicates a version which is too new.


### PR DESCRIPTION
This is the the first PR needed to support replacement of charts during `jx gitops upgrade`

The StableVersion struct is the one declaring the format of the defaults.yaml files for the charts in the version stream.

My particular use case is that [wave](https://github.com/wave-k8s/wave/) has gotten a new release (supporting current Kubernetes version). That project also publishes it's own helm chart now which could be used instead of https://github.com/jenkins-x-charts/pusher-wave. So I'd like to replace it so we don't need to maintain pusher-wave any more.

There have been cases in the past, see https://github.com/jenkins-x-plugins/jx-gitops/blob/125717bd5f906e04d7f3951937a0685078878c93/pkg/cmd/helmfile/resolve/resolve.go#L723