### PR TITLE
chore(activities): drop vestigial "Release" placeholder

### DIFF
--- a/pkg/kube/activities/activity.go
+++ b/pkg/kube/activities/activity.go
@@ -546,27 +546,6 @@ func (k *PromoteStepActivityKey) GetOrCreatePreview(jxClient versioned.Interface
 			return a, step, step.Preview, false, nil
 		}
 	}
-	// if there is no initial release Stage lets add one
-	if len(spec.Steps) == 0 {
-		endTime := time.Now()
-		startTime := endTime.Add(-1 * time.Minute)
-
-		spec.Steps = append(spec.Steps, v1.PipelineActivityStep{
-			Kind: v1.ActivityStepKindTypeStage,
-			Stage: &v1.StageActivityStep{
-				CoreActivityStep: v1.CoreActivityStep{
-					StartedTimestamp: &metav1.Time{
-						Time: startTime,
-					},
-					CompletedTimestamp: &metav1.Time{
-						Time: endTime,
-					},
-					Status: v1.ActivityStatusTypeSucceeded,
-					Name:   "Release",
-				},
-			},
-		})
-	}
 	// lets add a new step
 	preview := &v1.PreviewActivityStep{
 		CoreActivityStep: v1.CoreActivityStep{
@@ -635,27 +614,6 @@ func (k *PromoteStepActivityKey) GetOrCreatePromote(jxClient versioned.Interface
 		if k.matchesPromote(step) {
 			return a, step, step.Promote, false, nil
 		}
-	}
-	// if there is no initial release Stage lets add one
-	if len(spec.Steps) == 0 {
-		endTime := time.Now()
-		startTime := endTime.Add(-1 * time.Minute)
-
-		spec.Steps = append(spec.Steps, v1.PipelineActivityStep{
-			Kind: v1.ActivityStepKindTypeStage,
-			Stage: &v1.StageActivityStep{
-				CoreActivityStep: v1.CoreActivityStep{
-					StartedTimestamp: &metav1.Time{
-						Time: startTime,
-					},
-					CompletedTimestamp: &metav1.Time{
-						Time: endTime,
-					},
-					Status: v1.ActivityStatusTypeSucceeded,
-					Name:   "Release",
-				},
-			},
-		})
 	}
 	// lets add a new step
 	promote := &v1.PromoteActivityStep{

--- a/pkg/kube/activities/activity_test.go
+++ b/pkg/kube/activities/activity_test.go
@@ -156,19 +156,11 @@ func TestCreateOrUpdateActivities(t *testing.T) {
 	a, err := jxClient.JenkinsV1().PipelineActivities(nsObj.Namespace).Get(context.TODO(), expectedName, metav1.GetOptions{})
 	assert.NotNil(t, a, "should have a PipelineActivity for %s", expectedName)
 	steps := a.Spec.Steps
-	assert.Equal(t, 2, len(steps), "Should have 2 steps!")
+	assert.Equal(t, 1, len(steps), "Should have 1 step!")
 	step := a.Spec.Steps[0]
-	stage := step.Stage
-	assert.NotNil(t, stage, "step 0 should have a Stage")
-	assert.Equal(t, v1.ActivityStepKindTypeStage, step.Kind, "step - kind")
-	assert.Equal(t, v1.ActivityStatusTypeSucceeded, stage.Status, "step 0 Stage status")
-	assert.NotNil(t, stage.StartedTimestamp, "stage should have a StartedTimestamp")
-	assert.NotNil(t, stage.CompletedTimestamp, "stage should have a CompletedTimestamp")
-
-	step = a.Spec.Steps[1]
 	promote := step.Promote
-	assert.NotNil(t, promote, "step 1 should have a Promote")
-	assert.Equal(t, v1.ActivityStepKindTypePromote, step.Kind, "step 1 kind")
+	assert.NotNil(t, promote, "step 0 should have a Promote")
+	assert.Equal(t, v1.ActivityStepKindTypePromote, step.Kind, "step 0 kind")
 
 	pullRequestStep := promote.PullRequest
 	assert.NotNil(t, pullRequestStep, "Promote should have a PullRequest")


### PR DESCRIPTION
## Summary

`GetOrCreatePreview` and `GetOrCreatePromote` inserted a fake `"Release"` Stage entry into `PipelineActivity.Spec.Steps` whenever they wrote to an empty PA. This was a UX hack from an earlier era (PA single-writer, dashboard needing at least one Stage to render) and is no longer needed.

A grep across every jenkins-x repo found:
- 2 producers (these two functions).
- 0 actual consumers.
- 1 defensive reference: `jx-pipeline/pipelines.go:311` explicitly *excludes* the Release name when checking "does the PA have real stages?" — i.e., already treats it as a placeholder to ignore.

In practice it shows up as a phantom 1-minute Succeeded "Release" stage on the dashboard whenever jx-preview/jx-promote raced ahead of jx-build-controller's first stage update, and it shifted positional indexing in older `addTaskRunsMessage` code paths (separately fixed in jenkins-x-plugins/jx-pipeline#593).

## Test plan

- [x] `go test ./...` passes
- [x] Confirmed via grep that no consumer reads `Stage.Name == "Release"`