### PR TITLE
feat: add HTTPRoute as source for service URL finder

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -125,6 +125,151 @@ func FindURLFromVSIstio(dynamicClient dynamic.Interface, namespace, name string)
 	return getURLFromVirtualService(virtualService)
 }
 
+// getHTTPRoute gets the named HTTPRoute. The dynamic client must already be realized.
+func getHTTPRoute(dynamicClient dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	httpRouteGVR := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1",
+		Resource: "httproutes",
+	}
+	return dynamicClient.Resource(httpRouteGVR).Namespace(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+}
+
+// getGateway gets the named Gateway. The dynamic client must already be realized.
+func getGateway(dynamicClient dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	gatewayGVR := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1",
+		Resource: "gateways",
+	}
+	return dynamicClient.Resource(gatewayGVR).Namespace(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+}
+
+// parseGatewayParentRef extracts the parent Gateway reference from the HTTPRoute spec.
+func parseGatewayParentRef(httpRouteNamespace string, spec map[string]interface{}) (namespace, name, sectionName string, err error) {
+	parentRefs, ok := spec["parentRefs"].([]interface{})
+	if !ok || len(parentRefs) == 0 {
+		return "", "", "", errors.New("missing spec.parentRefs in the HTTPRoute")
+	}
+	parentRef, ok := parentRefs[0].(map[string]interface{})
+	if !ok {
+		return "", "", "", errors.New("invalid spec.parentRefs[0] in the HTTPRoute")
+	}
+	name, _ = parentRef["name"].(string)
+	if name == "" {
+		return "", "", "", errors.New("missing spec.parentRefs[0].name in the HTTPRoute")
+	}
+	namespace = httpRouteNamespace
+	if ns, ok := parentRef["namespace"].(string); ok && ns != "" {
+		namespace = ns
+	}
+	sectionName, _ = parentRef["sectionName"].(string)
+	return namespace, name, sectionName, nil
+}
+
+// getGatewayListenerProtocol returns the protocol (HTTP/HTTPS) of the parent Gateway's listener.
+func getGatewayListenerProtocol(dynamicClient dynamic.Interface, namespace, name, sectionName string) (string, error) {
+	gateway, err := getGateway(dynamicClient, namespace, name)
+	if err != nil {
+		return "", err
+	}
+	return getListenerProtocol(gateway, sectionName)
+}
+
+// getListenerProtocol returns the protocol of the Gateway listener named by sectionName, or the first listener when empty.
+func getListenerProtocol(gateway *unstructured.Unstructured, sectionName string) (string, error) {
+	spec, ok := gateway.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("no spec found in the Gateway")
+	}
+	listeners, ok := spec["listeners"].([]interface{})
+	if !ok || len(listeners) == 0 {
+		return "", errors.New("no listeners found in the Gateway")
+	}
+	for _, l := range listeners {
+		listener, ok := l.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// when a sectionName is given, only the listener with the matching name is relevant
+		if sectionName != "" {
+			if name, _ := listener["name"].(string); name != sectionName {
+				continue
+			}
+		}
+		if protocol, ok := listener["protocol"].(string); ok && protocol != "" {
+			return protocol, nil
+		}
+		// no sectionName: only the first listener is considered
+		if sectionName == "" {
+			break
+		}
+	}
+	return "", errors.New("no matching listener protocol found in the Gateway")
+}
+
+// getURLFromHTTPRoute builds the URL from the HTTPRoute's hostname and parent Gateway scheme.
+func getURLFromHTTPRoute(dynamicClient dynamic.Interface, httpRoute *unstructured.Unstructured) (string, error) {
+	spec, ok := httpRoute.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("missing spec in the HTTPRoute")
+	}
+	hostnames, ok := spec["hostnames"].([]interface{})
+	if !ok || len(hostnames) == 0 {
+		return "", errors.New("missing spec.hostnames in the HTTPRoute")
+	}
+	hostname, ok := hostnames[0].(string)
+	if !ok || hostname == "" {
+		return "", errors.New("invalid spec.hostnames[0] in the HTTPRoute")
+	}
+
+	// a malformed parentRef means the HTTPRoute is invalid - surface it
+	gatewayNamespace, gatewayName, sectionName, err := parseGatewayParentRef(httpRoute.GetNamespace(), spec)
+	if err != nil {
+		return "", err
+	}
+
+	// derive the scheme from the parent Gateway listener's protocol, defaulting to http
+	scheme := "http"
+	protocol, err := getGatewayListenerProtocol(dynamicClient, gatewayNamespace, gatewayName, sectionName)
+	if err != nil {
+		log.Logger().Debugf("unable to determine protocol from parent Gateway listener, defaulting to http: %s", err)
+	} else if strings.EqualFold(protocol, "HTTPS") {
+		scheme = "https"
+	}
+	return scheme + "://" + hostname, nil
+}
+
+// FindURLFromHTTPRoute finds the URL from the HTTPRoute resource, realizing a dynamic client if needed.
+func FindURLFromHTTPRoute(dynamicClient dynamic.Interface, namespace, name string) (string, error) {
+	dynamicClient, err := kube.LazyCreateDynamicClient(dynamicClient)
+	if err != nil {
+		return "", err
+	}
+	return findURLFromHTTPRouteRealized(dynamicClient, namespace, name)
+}
+
+// findURLFromHTTPRouteRealized finds the HTTPRoute URL using an already-realized dynamic client.
+func findURLFromHTTPRouteRealized(dynamicClient dynamic.Interface, namespace, name string) (string, error) {
+	log.Logger().Debugf("finding url from HTTP route %s in namespace %s", name, namespace)
+	httpRoute, err := getHTTPRoute(dynamicClient, namespace, name)
+	if err != nil {
+		switch {
+		// HTTPRoute is optional: missing resource, CRD or lack of RBAC should not surface an error
+		case apierrors.IsNotFound(err), apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+			log.Logger().Debugf("HTTPRoute %s not reachable in namespace %s", name, namespace)
+			return "", nil
+		default:
+			return "", fmt.Errorf("finding the HTTP route %s in namespace %s: %w", name, namespace, err)
+		}
+	}
+	log.Logger().Debugf("attempting to find URL via HTTPRoute")
+	url, err := getURLFromHTTPRoute(dynamicClient, httpRoute)
+	if err != nil {
+		return "", fmt.Errorf("parsing HTTPRoute %s/%s: %w", namespace, name, err)
+	}
+	return url, nil
+}
 
 // FindURLFromIngress finds the URL from the Ingress resource using the kubernetes client
 func FindURLFromIngress(client kubernetes.Interface, namespace string, name string) (string, error) {
@@ -182,17 +327,37 @@ func FindServiceURLWithDynamicClient(client kubernetes.Interface, namespace stri
 		return url, nil
 	}
 
-	log.Logger().Debugf("couldn't find url via ingress, attempting to look up via istio virtual services")
+	log.Logger().Debugf("couldn't find url via ingress, attempting to look up via HTTPRoute")
 
-	// let's try finding the service via Istio Virtual Services
-	url, vsErr := FindURLFromVSIstio(dynamicClient, namespace, name)
-	// log errors from Istio but don't propagate them as Istio is an optional dependency
-	if vsErr != nil {
-		log.Logger().Debugf("unable to find url via istio virtual service for %s in namespace %s - err %s", name, namespace, vsErr)
-	}
-	if url != "" {
-		log.Logger().Debugf("Found istio virtual service url %s", url)
-		return url, nil
+	// realize the dynamic client once and share it across the HTTPRoute and Istio lookups. these
+	// are skipped entirely when a client can't be built, so the realized helpers never get a nil client.
+	dynamicClient, dcErr := kube.LazyCreateDynamicClient(dynamicClient)
+	if dcErr != nil {
+		log.Logger().Debugf("unable to create dynamic client for %s in namespace %s, skipping HTTPRoute and istio lookups - err %s", name, namespace, dcErr)
+	} else {
+		// let's try finding the URL via HTTPRoute
+		// use a dedicated error variable so an optional HTTPRoute failure doesn't clobber a genuine ingress error
+		url, hrErr := findURLFromHTTPRouteRealized(dynamicClient, namespace, name)
+		if hrErr != nil {
+			log.Logger().Debugf("unable to find url via HTTPRoute for %s in namespace %s - err %s", name, namespace, hrErr)
+		}
+		if url != "" {
+			log.Logger().Debugf("found HTTPRoute url %s", url)
+			return url, nil
+		}
+
+		log.Logger().Debugf("couldn't find url via HTTPRoute, attempting to look up via istio virtual services")
+
+		// let's try finding the service via Istio Virtual Services
+		url, vsErr := FindURLFromVSIstio(dynamicClient, namespace, name)
+		// log errors from Istio but don't propagate them as Istio is an optional dependency
+		if vsErr != nil {
+			log.Logger().Debugf("unable to find url via istio virtual service for %s in namespace %s - err %s", name, namespace, vsErr)
+		}
+		if url != "" {
+			log.Logger().Debugf("Found istio virtual service url %s", url)
+			return url, nil
+		}
 	}
 
 	// nothing found anywhere - if a lookup action errored, surface it here

--- a/pkg/kube/services/services_test.go
+++ b/pkg/kube/services/services_test.go
@@ -25,6 +25,15 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
+// gatewayGVR is the real resource for a Gateway API Gateway. Tests insert Gateways
+// under this GVR explicitly because the fake dynamic client's kind->resource heuristic
+// mispluralises "Gateway" to "gatewaies".
+var gatewayGVR = schema.GroupVersionResource{
+	Group:    "gateway.networking.k8s.io",
+	Version:  "v1",
+	Resource: "gateways",
+}
+
 func TestMain(m *testing.M) {
 	// warm up jx-logging before parallel tests fan out to prevent a global init race
 	log.Logger()
@@ -500,6 +509,155 @@ func TestGetURLFromVirtualService(t *testing.T) {
 	}
 }
 
+func TestFindURLFromHTTPRoute(t *testing.T) {
+	t.Parallel()
+	const namespace = "jx"
+	const name = "myapp"
+
+	newHTTPRoute := func(hostname, gatewayName, sectionName string) *unstructured.Unstructured {
+		parentRef := map[string]interface{}{"name": gatewayName}
+		if sectionName != "" {
+			parentRef["sectionName"] = sectionName
+		}
+		u := &unstructured.Unstructured{}
+		u.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+			"spec": map[string]interface{}{
+				"parentRefs": []interface{}{parentRef},
+				"hostnames":  []interface{}{hostname},
+			},
+		})
+		return u
+	}
+
+	newGateway := func(gatewayName string, listeners ...map[string]interface{}) *unstructured.Unstructured {
+		ls := make([]interface{}, 0, len(listeners))
+		for _, l := range listeners {
+			ls = append(ls, l)
+		}
+		u := &unstructured.Unstructured{}
+		u.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata":   map[string]interface{}{"name": gatewayName, "namespace": namespace},
+			"spec":       map[string]interface{}{"listeners": ls},
+		})
+		return u
+	}
+
+	httpsListener := map[string]interface{}{"name": "https", "protocol": "HTTPS", "port": int64(443)}
+	httpListener := map[string]interface{}{"name": "http", "protocol": "HTTP", "port": int64(80)}
+
+	// newClient seeds a fake dynamic client. The HTTPRoute is added normally, but the Gateway
+	// must be inserted under its real "gateways" resource: the fake client's UnsafeGuessKindToResource
+	// heuristic mispluralises kind "Gateway" to "gatewaies", so a plain Add would not be GET-able.
+	newClient := func(httpRoute, gateway *unstructured.Unstructured) dynamic.Interface {
+		c := fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), httpRoute)
+		if gateway != nil {
+			err := c.Tracker().Create(gatewayGVR, gateway, gateway.GetNamespace())
+			assert.NoError(t, err)
+		}
+		return c
+	}
+
+	// newRouteClient seeds a fake client holding a single HTTPRoute with the given (possibly malformed) spec.
+	newRouteClient := func(spec map[string]interface{}) dynamic.Interface {
+		u := &unstructured.Unstructured{}
+		u.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+			"spec":       spec,
+		})
+		return fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), u)
+	}
+
+	// errClient returns a client whose GET on httproutes fails with the given error.
+	errClient := func(getErr error) dynamic.Interface {
+		c := fakedyn.NewSimpleDynamicClient(runtime.NewScheme())
+		c.PrependReactor("get", "httproutes", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, getErr
+		})
+		return c
+	}
+	groupResource := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}
+
+	testCases := []struct {
+		name        string
+		client      dynamic.Interface
+		expectedURL string
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:        "no HTTPRoute present is swallowed",
+			client:      fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
+			expectedURL: "",
+		},
+		{
+			name:        "pinned HTTPS listener -> https",
+			client:      newClient(newHTTPRoute("myapp.example.com", "gw", "https"), newGateway("gw", httpListener, httpsListener)),
+			expectedURL: "https://myapp.example.com",
+		},
+		{
+			name:        "first listener HTTP, no sectionName -> http",
+			client:      newClient(newHTTPRoute("myapp.example.com", "gw", ""), newGateway("gw", httpListener, httpsListener)),
+			expectedURL: "http://myapp.example.com",
+		},
+		{
+			name:        "parent Gateway absent -> best-effort http",
+			client:      newClient(newHTTPRoute("myapp.example.com", "missing-gw", "https"), nil),
+			expectedURL: "http://myapp.example.com",
+		},
+		{
+			// malformed content surfaces an error carrying the HTTPRoute identity, not best-effort http
+			name:        "no parentRefs -> error with identity",
+			client:      newRouteClient(map[string]interface{}{"hostnames": []interface{}{"myapp.example.com"}}),
+			expectErr:   true,
+			errContains: namespace + "/" + name,
+		},
+		{
+			name:      "no hostnames -> error",
+			client:    newRouteClient(map[string]interface{}{"parentRefs": []interface{}{map[string]interface{}{"name": "gw"}}}),
+			expectErr: true,
+		},
+		{
+			name:        "Forbidden is swallowed",
+			client:      errClient(apierrors.NewForbidden(groupResource, name, fmt.Errorf("no access"))),
+			expectedURL: "",
+		},
+		{
+			name:        "Unauthorized is swallowed",
+			client:      errClient(apierrors.NewUnauthorized("no auth")),
+			expectedURL: "",
+		},
+		{
+			name:      "internal error propagates",
+			client:    errClient(apierrors.NewInternalError(fmt.Errorf("boom"))),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			url, err := services.FindURLFromHTTPRoute(tc.client, namespace, name)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tc.errContains != "" {
+				assert.ErrorContains(t, err, tc.errContains)
+			}
+			assert.Equal(t, tc.expectedURL, url)
+		})
+	}
+}
+
 func TestFindURLFromService(t *testing.T) {
 	t.Parallel()
 	const namespace = "jx"
@@ -581,6 +739,42 @@ func TestFindServiceURLWithDynamicClient(t *testing.T) {
 		"spec":       map[string]interface{}{"hosts": []interface{}{"myapp.example.com"}},
 	})
 
+	httpRoute := &unstructured.Unstructured{}
+	httpRoute.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+		"spec": map[string]interface{}{
+			"parentRefs": []interface{}{map[string]interface{}{"name": "gw", "sectionName": "https"}},
+			"hostnames":  []interface{}{"route.example.com"},
+		},
+	})
+	gateway := &unstructured.Unstructured{}
+	gateway.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]interface{}{"name": "gw", "namespace": namespace},
+		"spec": map[string]interface{}{
+			"listeners": []interface{}{map[string]interface{}{"name": "https", "protocol": "HTTPS", "port": int64(443)}},
+		},
+	})
+	// HTTPRoute is added normally; the Gateway must be inserted under its real "gateways" resource
+	httpRouteClient := fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), httpRoute)
+	if err := httpRouteClient.Tracker().Create(gatewayGVR, gateway, namespace); err != nil {
+		t.Fatal(err)
+	}
+
+	// a malformed HTTPRoute (valid hostname, but no parentRefs) makes FindURLFromHTTPRoute return
+	// an error; the orchestrator should swallow it - like Istio - and keep falling through
+	malformedRoute := &unstructured.Unstructured{}
+	malformedRoute.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+		"spec":       map[string]interface{}{"hostnames": []interface{}{"route.example.com"}},
+	})
+	malformedRouteClient := fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), malformedRoute)
+
 	// clientset whose service GET fails with a non-NotFound error
 	errClient := fake.NewSimpleClientset()
 	errClient.PrependReactor("get", "services", func(clienttesting.Action) (bool, runtime.Object, error) {
@@ -623,10 +817,23 @@ func TestFindServiceURLWithDynamicClient(t *testing.T) {
 			expectedURL:   "http://ing.example.com",
 		},
 		{
+			name:          "falls through to HTTPRoute",
+			client:        fake.NewSimpleClientset(),
+			dynamicClient: httpRouteClient,
+			expectedURL:   "https://route.example.com",
+		},
+		{
 			name:          "falls through to istio",
 			client:        fake.NewSimpleClientset(),
 			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), vsWithHost),
 			expectedURL:   "http://myapp.example.com",
+		},
+		{
+			// malformed HTTPRoute error is swallowed (no expectErr) and the chain falls through
+			name:          "malformed HTTPRoute is swallowed",
+			client:        fake.NewSimpleClientset(),
+			dynamicClient: malformedRouteClient,
+			expectedURL:   "",
 		},
 		{
 			name:          "nothing found",


### PR DESCRIPTION
### Changes
* Add `FindURLFromHTTPRoute` to dynamically resolve a service URL for a Gateway API `HTTPRoute` resource
* Add helpers to read the `HTTPRoute`/`Gateway` resources and derive the scheme (http/https) from the parent Gateway listener's protocol, defaulting to http when the Gateway can't be read
* Wire `HTTPRoute` lookup into `FindServiceURLWithDynamicClient`, slotting it in after Ingress and before Istio VirtualServices
* Add test coverage for the new HTTPRoute URL resolution.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                         
### Context
When using the Gateway API, service hostnames are exposed using a `HTTPRoute` rather than `Ingress` or Istio's `VirtualServices`.

This adds HTTPRoute as a source in the URL finder chain so URLs can resolve correctly when the Gateway API is used.