### PR TITLE
fix: check whether k8s client supports WatchList semantics

### DIFF
--- a/pkg/kube/pods/pod.go
+++ b/pkg/kube/pods/pod.go
@@ -3,7 +3,6 @@ package pods
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -168,17 +167,23 @@ func WaitForPod(client kubernetes.Interface, namespace string, optionsModifier f
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	watch, err := tools_watch.UntilWithSync(ctx, cache.ToListWatcherWithWatchListSemantics(lw, client), &v1.Pod{}, func(store cache.Store) (bool, error) { return false, nil }, func(event watch.Event) (bool, error) {
-		pod := event.Object.(*v1.Pod)
-		if pod == nil {
-			return false, errors.New("watched object is not a Pod")
+	checkPod := func(event watch.Event) (bool, error) {
+		if event.Type == watch.Error {
+			return false, apierrors.FromObject(event.Object)
+		}
+		pod, ok := event.Object.(*v1.Pod)
+		if !ok {
+			return false, fmt.Errorf("watched object is not a Pod: %T", event.Object)
 		}
 		return condition(pod), nil
-	})
+	}
+
+	listWatcher := cache.ToListWatcherWithWatchListSemantics(lw, client)
+	result, err := tools_watch.UntilWithSync(ctx, listWatcher, &v1.Pod{}, func(_ cache.Store) (bool, error) { return false, nil }, checkPod)
 	if err != nil {
 		return nil, err
 	}
-	return watch.Object.(*v1.Pod), nil
+	return result.Object.(*v1.Pod), nil
 }
 
 // ListOptionsString returns a string summary of the list options

--- a/pkg/kube/pods/pod.go
+++ b/pkg/kube/pods/pod.go
@@ -154,9 +154,6 @@ func GetCurrentPod(kubeClient kubernetes.Interface, ns string) (*v1.Pod, error) 
 
 // WaitForPod waits for a pod filtered by `optionsModifier` that match `condition`
 func WaitForPod(client kubernetes.Interface, namespace string, optionsModifier func(options *metav1.ListOptions), timeout time.Duration, condition PodPredicate) (*v1.Pod, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	lw := &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, o metav1.ListOptions) (runtime.Object, error) {
 			optionsModifier(&o)
@@ -167,6 +164,9 @@ func WaitForPod(client kubernetes.Interface, namespace string, optionsModifier f
 			return client.CoreV1().Pods(namespace).Watch(ctx, o)
 		},
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
 	watch, err := tools_watch.UntilWithSync(ctx, cache.ToListWatcherWithWatchListSemantics(lw, client), &v1.Pod{}, func(store cache.Store) (bool, error) { return false, nil }, func(event watch.Event) (bool, error) {
 		pod := event.Object.(*v1.Pod)

--- a/pkg/kube/pods/pod.go
+++ b/pkg/kube/pods/pod.go
@@ -154,21 +154,21 @@ func GetCurrentPod(kubeClient kubernetes.Interface, ns string) (*v1.Pod, error) 
 
 // WaitForPod waits for a pod filtered by `optionsModifier` that match `condition`
 func WaitForPod(client kubernetes.Interface, namespace string, optionsModifier func(options *metav1.ListOptions), timeout time.Duration, condition PodPredicate) (*v1.Pod, error) {
-
-	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
 	lw := &cache.ListWatch{
-		ListFunc: func(o metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, o metav1.ListOptions) (runtime.Object, error) {
 			optionsModifier(&o)
-			return client.CoreV1().Pods(namespace).List(context.TODO(), o)
+			return client.CoreV1().Pods(namespace).List(ctx, o)
 		},
-		WatchFunc: func(o metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, o metav1.ListOptions) (watch.Interface, error) {
 			optionsModifier(&o)
-			return client.CoreV1().Pods(namespace).Watch(context.TODO(), o)
+			return client.CoreV1().Pods(namespace).Watch(ctx, o)
 		},
 	}
 
-	watch, err := tools_watch.UntilWithSync(ctx, lw, &v1.Pod{}, func(store cache.Store) (bool, error) { return false, nil }, func(event watch.Event) (bool, error) {
+	watch, err := tools_watch.UntilWithSync(ctx, cache.ToListWatcherWithWatchListSemantics(lw, client), &v1.Pod{}, func(store cache.Store) (bool, error) { return false, nil }, func(event watch.Event) (bool, error) {
 		pod := event.Object.(*v1.Pod)
 		if pod == nil {
 			return false, errors.New("watched object is not a Pod")

--- a/pkg/kube/pods/pod_test.go
+++ b/pkg/kube/pods/pod_test.go
@@ -20,8 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	clientfeatures "k8s.io/client-go/features"
-	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -340,7 +338,7 @@ func TestIsPodReadyFailures(t *testing.T) {
 }
 
 func TestWaitForPodSelectorToBeReady(t *testing.T) {
-	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	t.Parallel()
 
 	testers := []func(client kubernetes.Interface){
 		func(client kubernetes.Interface) {


### PR DESCRIPTION
### Changes
1. Use `cache.ToListWatcherWithWatchListSemantics()` with `UntilWithSync()` - main reason why I'm here.
2. Move to `WithContext()` funcs as previous are deprecated
3. Fix leaking `context.WithTimeout()` cancel func
4. Handle error/type errors from `UntilWithSync()`

### Context
1.
With `client-go` v0.34+ the `WatchListClient` feature gate was enabled by default. This means that `tools_watch.UntilWithSync` uses streaming WatchList semantics — the reflector calls `Watch` with `SendInitialEvents=true` and waits for a synthetic `Bookmark` event before marking caches synced.

The fake clientset doesn't implement WatchList semantics and signals this by implementing `IsWatchListSemanticsUnSupported()` on the client. But without `cache.ToListWatcherWithWatchListSemantics()` `UntilWithSync()` doesn't know this and so expects the `Bookmark` event that never comes causing tests to timeout with the error:
```log
UntilWithSync: unable to sync caches: context deadline exceeded
```
As seen in https://github.com/jenkins-x-plugins/jx-secret/pull/438.

This is purely a testing issue as a the real client set doesn't implement the method so wrapper returns `false` causing the reflector to use streaming WatchList.

2. Non-context function on `cache.ListWatch{}` are now deprecated.

3. Boyscout as the cancel func was discarded, leaking the timer until GC.

4. Copilot review. Refactored so that we know whether there is an error and also whether the event is of pod type. Moved the conditional logic into the `UntilWithSync()` call as it makes sense to be there rather than post the call.

### Testing
Ran against local version of jx-secret and tests now pass. Also ran regression test without the `ToListWatcherWithWatchListSemantics()` wrapper and confirmed it fails prior to the fix.
